### PR TITLE
Changes to QueryDatasetFromStruct __getitem__ method

### DIFF
--- a/pittsburgh.py
+++ b/pittsburgh.py
@@ -227,7 +227,7 @@ class QueryDatasetFromStruct(data.Dataset):
             negSample = np.random.choice(self.potential_negatives[index], self.nNegSample)
             negSample = np.unique(np.concatenate([self.negCache[index], negSample]))
 
-            negFeat = h5feat[negSample.tolist()]
+            negFeat = h5feat[list(map(int, negSample))]
             knn.fit(negFeat)
 
             dNeg, negNN = knn.kneighbors(qFeat.reshape(1,-1), 


### PR DESCRIPTION
f5feat[negSample.tolist()] index's h5feat with a list of floats. 

Changing to h5feat[list(map(int, negSample))] avoids this issue.